### PR TITLE
FKDEV-29: Talking event

### DIFF
--- a/src/plugin/VideoRoomPublisherJanusPlugin.js
+++ b/src/plugin/VideoRoomPublisherJanusPlugin.js
@@ -291,7 +291,7 @@ class VideoRoomPublisherJanusPlugin extends JanusPlugin {
     }
 
     if (videoroom === 'stopped-talking') {
-      this.emit('stopped-talking')
+      this.emit('stoppedTalking')
       return
     }
 

--- a/src/plugin/VideoRoomPublisherJanusPlugin.js
+++ b/src/plugin/VideoRoomPublisherJanusPlugin.js
@@ -285,6 +285,16 @@ class VideoRoomPublisherJanusPlugin extends JanusPlugin {
       return
     }
 
+    if (videoroom === 'talking') {
+      this.emit('talking')
+      return
+    }
+
+    if (videoroom === 'stopped-talking') {
+      this.emit('stopped-talking')
+      return
+    }
+
     this.logger.error('VideoRoomPublisherJanusPlugin unhandled message:', videoroom, json)
   }
 }


### PR DESCRIPTION
### Summary:

Janus esemény beszédre.
A janusConfigban be kell hozzá kapcsolni az `audiolevelEvent`-et.
Csökkenteni kell az `audioActivePackets`-et.
Az alapbeállítás 100, ami 2 másodpercet jelent, tehát a zajnak legalább addig kell tartania. Én a fél másodpercet (25) ajánlom.
Az audioLevelAverage-et érdemes növelni. Az alapbeállítás 25, én a 40-et javaslom, ez egy kicsit alacsonyabb hangerőt jelent.

### References:

**YouTrack ticket(s):**

https://youtrack.techteamer.com/youtrack/issue/FKDEV-29

**Related PR(s):**

https://github.com/TechTeamer/vuer_oss/pull/2641
https://github.com/TechTeamer/vuer_oss/pull/2631
