### PR TITLE
Forward keyframe events

### DIFF
--- a/src/plugin/VideoRoomPublisherJanusPlugin.js
+++ b/src/plugin/VideoRoomPublisherJanusPlugin.js
@@ -285,6 +285,11 @@ class VideoRoomPublisherJanusPlugin extends JanusPlugin {
       return
     }
 
+    if(videoroom === 'keyframe') {
+      this.emit('keyframe', data)
+      return
+    }
+
     if (videoroom === 'talking') {
       this.emit('talking')
       return


### PR DESCRIPTION
## Summary

Forward (custom) `keyframe`events.

### Example
```
{
  videoroom: 'keyframe',
  room: 4473808368667781,
  id: 4302698742002272,
  resolution: { width: 640, height: 360 }
}
```